### PR TITLE
[NHDR-123] feat: 로그아웃 시 Access Token 및 Refresh Token 삭제 로직 구현 완료

### DIFF
--- a/src/main/java/org/scoula/auth/controller/AuthController.java
+++ b/src/main/java/org/scoula/auth/controller/AuthController.java
@@ -2,15 +2,15 @@ package org.scoula.auth.controller;
 
 import java.util.Map;
 
-
 import org.scoula.auth.dto.LoginResponseDto;
 import org.scoula.auth.dto.RefreshTokenRequestDto;
 import org.scoula.auth.dto.TokenRefreshResponseDto;
 import org.scoula.auth.service.KakaoAuthService;
-import org.scoula.user.domain.UserVo;
-import org.scoula.user.dto.UserInfoDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 // @RequestMapping	// redirect 변경 시 수정
 public class AuthController {
 
+	private static final Logger log = LoggerFactory.getLogger(AuthController.class);
 	private final KakaoAuthService kakaoAuthService;
 
 	// ✅ 이 핸들러가 카카오 리디렉션을 처리함
@@ -56,11 +57,11 @@ public class AuthController {
 			if (e.getStatusCode() == HttpStatus.BAD_REQUEST &&
 				e.getResponseBodyAsString().contains("KOE320")) {
 				return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-					.body(Map.of("error","유효하지 않은 인가코드입니다."));
+					.body(Map.of("error", "유효하지 않은 인가코드입니다."));
 
 			}
 			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-				.body(Map.of("error","카카오 서버와 연결되지 않는 상태입니다. "));
+				.body(Map.of("error", "카카오 서버와 연결되지 않는 상태입니다. "));
 
 		}
 
@@ -76,5 +77,14 @@ public class AuthController {
 
 		TokenRefreshResponseDto responseDto = kakaoAuthService.reissueTokens(requestDto.getRefreshToken());
 		return ResponseEntity.ok(responseDto);
+	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<Void> logout(Authentication authentication) {
+		// SecurityContext에서 현재 인증된 사용자의 이메일을 가져온다.
+		String userEmail = authentication.getName();
+		kakaoAuthService.logout(userEmail);
+
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/org/scoula/auth/mapper/RefreshTokenMapper.java
+++ b/src/main/java/org/scoula/auth/mapper/RefreshTokenMapper.java
@@ -14,4 +14,7 @@ public interface RefreshTokenMapper {
 	// 이메일과 provider로 토큰을 조회하는 메서드 추가
 	// provider 파라미터 삭제
 	RefreshTokenDto findTokenByUserEmail(String userEmail);
+
+	void deleteRefreshToken(String userEmail);
+
 }

--- a/src/main/java/org/scoula/auth/service/KakaoAuthService.java
+++ b/src/main/java/org/scoula/auth/service/KakaoAuthService.java
@@ -203,4 +203,13 @@ public class KakaoAuthService {
 		// 4. 두 개의 새로운 토큰을 모두 반환
 		return new TokenRefreshResponseDto(newAccessToken, newRefreshToken);
 	}
+
+	/**
+	 * 로그아웃을 처리합니다. DB에서 사용자의 Refresh Token을 삭제합니다.
+	 * @param userEmail 로그아웃할 사용자의 이메일
+	 */
+	public void logout(String userEmail) {
+		// ✅ provider 파라미터 없이 userEmail만 사용하여 토큰을 삭제합니다.
+		refreshTokenMapper.deleteRefreshToken(userEmail);
+	}
 }

--- a/src/main/resources/org/scoula/auth/mapper/RefreshTokenMapper.xml
+++ b/src/main/resources/org/scoula/auth/mapper/RefreshTokenMapper.xml
@@ -16,5 +16,10 @@
         FROM refresh_token
         WHERE user_email = #{userEmail};
     </select>
-    
+
+    <delete id="deleteRefreshToken">
+        DELETE
+        FROM refresh_token
+        WHERE user_email = #{userEmail}
+    </delete>
 </mapper>


### PR DESCRIPTION
<!-- PR명: [티켓번호] 작업 주제 - 닉네임 -->

# 📝 작업 내용

<!-- 어떤 작업을 했는지 간단한 리스트업 -->
- 카카오 로그아웃 로직 구현
- 로그아웃 시 DB에 저장된 Refresh Token 삭제 로직 구현

# ✅ 체크리스트

- [x] `./gradlew build` 또는 `mvn clean install`: 정상 작동
- [x] Postman 또는 Swagger로 API 테스트 완료
- [x] 로컬 DB 연동 후 동작 확인
- [x] 예외 및 유효성 검증 로직 포함
- [x] 로그 및 주석 작성
- [x] 리뷰어 지정 및 리뷰 요청 완료
- [x] Jira in Review로 이동 완료
