### PR TITLE
[NHDR-146] feat: JwtAuthenticationFilter 화이트리스트 제거 및 토큰 관련 로직 수정

### DIFF
--- a/src/main/java/org/scoula/security/config/SecurityConfig.java
+++ b/src/main/java/org/scoula/security/config/SecurityConfig.java
@@ -50,29 +50,20 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 		http
 			.authorizeRequests()
-			.antMatchers(
+			// 💡 GET 요청 중 인증 없이 허용할 경로들
+			.antMatchers(HttpMethod.GET,
 				"/",
 				"/favicon.ico",
-				"/oauth/authorize",
-				"/api/faq/**"
+				"/api/home",
+				"/auth/kakao",
+				"/auth/kakao/callback"
 			).permitAll()
 			.antMatchers(HttpMethod.POST,
 				"/api/user/join",
 				"/auth/kakao",
 				"/auth/refresh"
 			).permitAll()
-			.antMatchers(HttpMethod.GET,
-				"/auth/kakao/callback",
-				"/api/home"
-			).permitAll()
-
-			// ✅ PATCH 요청 명시적으로 허용 추가 (예시: 내 지점 등록/수정 허용)
-			.antMatchers(HttpMethod.PATCH,
-				"/api/user/branch"
-			).authenticated()
-
-			.antMatchers(HttpMethod.OPTIONS).permitAll() // CORS Preflight
-
+			.antMatchers(HttpMethod.OPTIONS).permitAll()
 			.anyRequest().authenticated();
 	}
 


### PR DESCRIPTION
<!-- PR명: [티켓번호] 작업 주제 - 닉네임 -->

# 📝 작업 내용

<!-- 어떤 작업을 했는지 간단한 리스트업 -->
- JwtAuthenticationFilter 화이트리스트 제거

- JwtAuthenticationFilter 토큰 관련 로직 변경
  - 기존 토큰 로직은 화이트리스트를 제외하고 모든 URI Path에 대해서 access token을 요구
  - 현재는 토큰이 존재하고, 'Bearer '로 시작하며, 유효한 경우에만 인증 객체를 생성하여 SecurityContext에 저장
    - 토큰 유무나 유효성과 관계없이 항상 다음 필터로 요청을 전달
    - 접근 허용 여부는 SecurityConfig의 설정에 따라 Spring Security가 최종적으로 결정하도록 로직 변경

# ✅ 체크리스트

- [x] `./gradlew build` 또는 `mvn clean install`: 정상 작동
- [x] Postman 또는 Swagger로 API 테스트 완료
- [x] 로컬 DB 연동 후 동작 확인
- [x] 예외 및 유효성 검증 로직 포함
- [x] 로그 및 주석 작성
- [x] 리뷰어 지정 및 리뷰 요청 완료
- [x] Jira in Review로 이동 완료
