### PR TITLE
[NHDR-170] refactor: accessToken 사용하여 노후 자산현황 조회하도록 수정

### DIFF
--- a/src/main/java/org/scoula/asset/service/AssetStatusServiceImpl.java
+++ b/src/main/java/org/scoula/asset/service/AssetStatusServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.scoula.asset.domain.AssetStatusVo;
 import org.scoula.asset.dto.AssetStatusRequestDto;
 import org.scoula.asset.dto.AssetStatusResponseDto;
+import org.scoula.asset.dto.AssetStatusSummaryDto;
 import org.scoula.asset.mapper.AssetStatusMapper;
 import org.scoula.user.dto.UserDto;
 import org.scoula.user.service.UserService;
@@ -74,6 +75,14 @@ public class AssetStatusServiceImpl implements AssetStatusService {
 	public List<AssetStatusResponseDto> getAssetStatusByEmail(String email) {
 		return assetStatusMapper.findAssetStatusByEmail(email).stream()
 			.map(AssetStatusResponseDto::of)
+			.collect(Collectors.toList());
+	}
+
+	// 노후 페이지에서 보여질 자산현황에 쓰일 메서드입니다.
+	@Override
+	public List<AssetStatusSummaryDto> getAssetStatusSummaryByEmail(String email) {
+		return assetStatusMapper.findAssetStatusSummaryByEmail(email).stream()
+			.map(AssetStatusSummaryDto::of)
 			.collect(Collectors.toList());
 	}
 

--- a/src/main/java/org/scoula/retirement/controller/RetirementController.java
+++ b/src/main/java/org/scoula/retirement/controller/RetirementController.java
@@ -16,6 +16,7 @@ import org.scoula.user.dto.UserDto;
 import org.scoula.user.dto.UserInfoDto;
 import org.scoula.user.service.UserService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,9 +46,10 @@ public class RetirementController {
 	 * @return RetirementMainResponseDTO를 포함하는 ResponseEntity
 	 */
 	@GetMapping("")
-	public ResponseEntity<RetirementMainResponseDto> getRetirementMainData(@RequestParam String email) {
+	public ResponseEntity<RetirementMainResponseDto> getRetirementMainData(Authentication authentication) {
 		RetirementMainResponseDto response = new RetirementMainResponseDto();
 
+		String email = authentication.getName();
 		// 0. 사용자 정보 조회
 		UserDto userDto = userServiceImpl.getUser(email);
 		UserInfoDto userInfoDto = UserInfoDto.of(userDto.toVo());

--- a/src/main/java/org/scoula/security/config/SecurityConfig.java
+++ b/src/main/java/org/scoula/security/config/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 				"/api/home",
 				"/auth/kakao",
 				"/auth/kakao/callback",
+				"/api/retirement",
 				"/api/sms/test" // SMS API 경로  임시 추가 - 로그인 구현 후 제거
 			).permitAll()
 			.antMatchers(HttpMethod.POST,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ jdbc.driver=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
 jdbc.url=jdbc:log4jdbc:mysql://localhost:3306/jeju_gom
 jdbc.username=root
 jdbc.password=1234
-kakao.client.id=2f7a0916ce26520623207e04c4c27d25
+kakao.client.id=3915e266f2340851e307cca982620137
 kakao.redirect.uri=http://localhost:8080/auth/kakao/callback
 mybatis.mapper-locations:classpath:mapper/*.xml
 #


### PR DESCRIPTION
<!-- PR명: [티켓번호] 작업 주제 - 닉네임 -->

# 📝 작업 내용

<!-- 어떤 작업을 했는지 간단한 리스트업 -->
- `getRetirementMainData()` 노후 메인 페이지 진입 시 가져오는 메서드의 `@RequestParam`을 `Authentication`으로 변경
-> accessToken으로 사용자 정보 조회


# ✅ 체크리스트

- [v] `./gradlew build` 또는 `mvn clean install`: 정상 작동
- [v] Postman 또는 Swagger로 API 테스트 완료
- [v] 로컬 DB 연동 후 동작 확인
- [v] 예외 및 유효성 검증 로직 포함
- [v] 로그 및 주석 작성
- [v] 리뷰어 지정 및 리뷰 요청 완료
- [v] Jira in Review로 이동 완료
