### PR TITLE
[NHDR-201] feat: 상속 결과 페이지 기능 구현 및 증여 시뮬레이션 결과 HTTPMethod 수정-seyoung

### DIFF
--- a/src/main/java/org/scoula/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/scoula/exception/GlobalExceptionHandler.java
@@ -43,6 +43,14 @@ public class GlobalExceptionHandler {
 		return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
 	}
 
+	/**
+	 * UserNotFoundException 발생 시 처리하는 핸들러
+	 */
+	@ExceptionHandler(UserNotFoundException.class)
+	public ResponseEntity<ErrorResponse> handleUserNotFound(ProductNotFoundException ex) {
+		ErrorResponse error = new ErrorResponse("NOT_FOUND", ex.getMessage());
+		return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+	}
 
 	/**
 	 * 잘못된 파라미터 타입
@@ -104,9 +112,10 @@ public class GlobalExceptionHandler {
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(new ErrorResponse("서버 내부 오류", error.getMessage()));
 	}
+
 	@ExceptionHandler(HttpMessageNotReadableException.class)
-	public ResponseEntity<ErrorResponse> handleInvalidFormat(HttpMessageNotReadableException error){
-		log.error("잘못된 Json Format",error.getMessage(),error);
+	public ResponseEntity<ErrorResponse> handleInvalidFormat(HttpMessageNotReadableException error) {
+		log.error("잘못된 Json Format", error.getMessage(), error);
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(new ErrorResponse("잘못된 JSON 포맷", error.getMessage()));
 	}

--- a/src/main/java/org/scoula/exception/UserNotFoundException.java
+++ b/src/main/java/org/scoula/exception/UserNotFoundException.java
@@ -1,0 +1,16 @@
+package org.scoula.exception;
+
+// @ResponseStatus 어노테이션은 GlobalExceptionHandler가 있을 경우, 핸들러가 우선권을 가집니다.
+// 핸들러가 없을 때를 대비한 기본 방어 장치로 유용합니다.
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND) // 기본적으로 404 Not Found를 반환하도록 설정
+public class UserNotFoundException extends RuntimeException {
+
+	// 예외 메시지를 받는 생성자
+	public UserNotFoundException(String message) {
+		super("상품을 찾을 수 없습니다: " + message);
+	}
+}

--- a/src/main/java/org/scoula/gift/controller/SimulationController.java
+++ b/src/main/java/org/scoula/gift/controller/SimulationController.java
@@ -2,10 +2,11 @@ package org.scoula.gift.controller;
 
 import org.scoula.gift.dto.SimulationRequestDto;
 import org.scoula.gift.dto.SimulationResponseDto;
+import org.scoula.gift.dto.WillPageResponseDto;
 import org.scoula.gift.service.SimulationService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,7 +20,7 @@ public class SimulationController { // 컨트롤러 이름도 조금 더 명확�
 
 	private final SimulationService simulationService;
 
-	@PostMapping("/simulation")
+	@GetMapping("/simulation")
 	public ResponseEntity<SimulationResponseDto> runSimulation(
 		@RequestBody SimulationRequestDto requestDto, Authentication authentication) {
 
@@ -30,4 +31,22 @@ public class SimulationController { // 컨트롤러 이름도 조금 더 명확�
 
 		return ResponseEntity.ok(responseDto);
 	}
+
+	/**
+	 * 유언장 템플릿 페이지에 필요한 현재 로그인된 사용자 정보를 조회합니다.
+	 */
+	@GetMapping("/simulation/will")
+	public ResponseEntity<WillPageResponseDto> getWillTemplateUserInfo(
+		Authentication authentication) {
+
+		// 1. Spring Security Context에서 현재 로그인된 사용자의 이메일(username)을 가져옵니다.
+		String userEmail = authentication.getName();
+
+		// 2. Service 레이어에 로직 처리를 위임합니다.
+		WillPageResponseDto responseDto = simulationService.getUserInfoForWillPage(userEmail);
+
+		// 3. 성공적인 응답(200 OK)과 함께 DTO를 반환합니다.
+		return ResponseEntity.ok(responseDto);
+	}
+
 }

--- a/src/main/java/org/scoula/gift/dto/WillPageResponseDto.java
+++ b/src/main/java/org/scoula/gift/dto/WillPageResponseDto.java
@@ -1,0 +1,17 @@
+package org.scoula.gift.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 유언장 템플릿 페이지에 필요한 사용자 정보를 전달하는 DTO
+ */
+@Getter
+@Builder // 빌더 패턴을 사용하여 객체를 안전하고 명확하게 생성
+public class WillPageResponseDto {
+
+	private final String email;
+	private final String name;
+	private final String birth;
+
+}

--- a/src/main/java/org/scoula/gift/service/SimulationService.java
+++ b/src/main/java/org/scoula/gift/service/SimulationService.java
@@ -2,10 +2,13 @@ package org.scoula.gift.service;
 
 import org.scoula.gift.dto.SimulationRequestDto;
 import org.scoula.gift.dto.SimulationResponseDto;
+import org.scoula.gift.dto.WillPageResponseDto;
 
 public interface SimulationService {
 	/**
 	 * 증여세 시뮬레이션을 실행하고 전체 결과(세금, 절세전략 등)를 반환합니다.
 	 */
 	SimulationResponseDto runGiftTaxSimulation(SimulationRequestDto requestDto, String email);
+
+	WillPageResponseDto getUserInfoForWillPage(String email);
 }


### PR DESCRIPTION
<!-- PR명: [티켓번호] 작업 주제 - 닉네임 -->

# 📝 작업 내용

<!-- 어떤 작업을 했는지 간단한 리스트업 -->
- 증여 시뮬레이션 결과 페이지 조회 Post -> Get 요청으로 수정
<img width="1530" height="816" alt="image" src="https://github.com/user-attachments/assets/727d681c-b955-4cb8-94d5-979bfbe6f412" />

- 유언장 결과 페이지에 대한 GET 요청 API 구현
<img width="1548" height="475" alt="image" src="https://github.com/user-attachments/assets/c12e1b6c-6b64-4c8a-b9e1-090d47e552cd" />


# ✅ 체크리스트

- [x] `./gradlew build` 또는 `mvn clean install`: 정상 작동
- [x] Postman 또는 Swagger로 API 테스트 완료
- [x] 로컬 DB 연동 후 동작 확인
- [x] 예외 및 유효성 검증 로직 포함
- [x] 로그 및 주석 작성
- [x] 리뷰어 지정 및 리뷰 요청 완료
- [x] Jira in Review로 이동 완료
