### PR TITLE
[NHDR-208] fix: Codef 자산 재연동 시 기존 연동 자산 삭제

### DIFF
--- a/src/main/java/org/scoula/View/codef/service/CodefTokenService.java
+++ b/src/main/java/org/scoula/View/codef/service/CodefTokenService.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import javax.annotation.PostConstruct;
 
+import org.scoula.asset.domain.AssetStatusVo;
 import org.scoula.asset.dto.AssetStatusRequestDto;
 import org.scoula.asset.service.AssetStatusService;
 import org.scoula.View.codef.dto.ConnectedIdRequestDto;
@@ -145,6 +146,16 @@ public class CodefTokenService {
 				asset.setAssetName((String)account.get("resAccountName")); // 통장 이름
 				asset.setAmount(Long.parseLong((String)account.get("resAccountBalance")));
 				asset.setBusinessType(null);
+
+				/**
+				 * 자산 재연동 시엔, 이미 연동한 자산을 삭제 후 업데이트 하도록 수정
+				 */
+				List<AssetStatusVo> vos = assetStatusService.getFullAssetStatusByEmail(userEmail);
+				for(AssetStatusVo vo : vos){
+					if(vo.getAssetCategoryCode().equals("2"))
+						assetStatusService.deleteAssetStatus(vo.getAssetId(),userEmail);
+				}
+
 				assetStatusService.addAssetStatus(userEmail,asset);
 
 				/**


### PR DESCRIPTION
<!-- PR명: [티켓번호] 작업 주제 - 닉네임 -->
[NHDR-208]
# 📝 작업 내용

<!-- 어떤 작업을 했는지 간단한 리스트업 -->
- CODEF 자산 연동 후 재연동 시 , 자산이 중복되어 저장되지 않도록 기존 자산 삭제하는 로직 추가

-

# ✅ 체크리스트

- [ ] `./gradlew build` 또는 `mvn clean install`: 정상 작동
- [ ] Postman 또는 Swagger로 API 테스트 완료
- [ ] 로컬 DB 연동 후 동작 확인
- [ ] 예외 및 유효성 검증 로직 포함
- [ ] 로그 및 주석 작성
- [ ] 리뷰어 지정 및 리뷰 요청 완료
- [ ] Jira in Review로 이동 완료
