### PR TITLE
[NHDR-220] Fund 3개월 수익률 기능 추가

### DIFF
--- a/src/main/java/org/scoula/product/domain/FundDailyReturnVo.java
+++ b/src/main/java/org/scoula/product/domain/FundDailyReturnVo.java
@@ -1,0 +1,17 @@
+package org.scoula.product.domain;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+@Data
+public class FundDailyReturnVo {
+	private Long id;
+	private String fundCode;
+	private LocalDate recordDate;
+	private BigDecimal returnRate;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/scoula/product/dto/FundDailyReturnDto.java
+++ b/src/main/java/org/scoula/product/dto/FundDailyReturnDto.java
@@ -1,0 +1,28 @@
+package org.scoula.product.dto;
+
+import java.math.BigDecimal;
+import java.time.format.DateTimeFormatter;
+
+import org.scoula.product.domain.FundDailyReturnVo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString(callSuper = true)
+@Getter
+@AllArgsConstructor
+public class FundDailyReturnDto {
+	private String recordDate;
+	private BigDecimal returnRate;
+
+	// VO -> DTO 변환 메서드
+	public static FundDailyReturnDto of(FundDailyReturnVo vo) {
+		return new FundDailyReturnDto(
+			vo.getRecordDate().format(DateTimeFormatter.ISO_DATE), // "yyyy-MM-dd"
+			vo.getReturnRate()
+		);
+	}
+}

--- a/src/main/java/org/scoula/product/mapper/FundDailyReturnMapper.java
+++ b/src/main/java/org/scoula/product/mapper/FundDailyReturnMapper.java
@@ -1,0 +1,13 @@
+package org.scoula.product.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.scoula.product.domain.FundDailyReturnVo;
+
+@Mapper
+public interface FundDailyReturnMapper {
+	List<FundDailyReturnVo> findByFundCode(@Param("fundCode") String fundCode);
+
+}

--- a/src/main/java/org/scoula/product/service/ProductService.java
+++ b/src/main/java/org/scoula/product/service/ProductService.java
@@ -3,6 +3,7 @@ package org.scoula.product.service;
 import java.util.List;
 import java.util.Map;
 
+import org.scoula.product.domain.FundDailyReturnVo;
 import org.scoula.product.domain.ProductVo;
 import org.scoula.product.dto.ProductDto;
 
@@ -23,4 +24,5 @@ public interface ProductService {
 	public ProductVo getProductDetail(String finPrdtCd);
 
 	String getProductNameByCode(String finPrdtCode);
+	List<FundDailyReturnVo> getFundDailyReturnByCode(String finPrdtCd);
 }

--- a/src/main/java/org/scoula/product/service/ProductsServiceImpl.java
+++ b/src/main/java/org/scoula/product/service/ProductsServiceImpl.java
@@ -6,25 +6,18 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.scoula.product.domain.DepositVo;
+import org.scoula.product.domain.FundDailyReturnVo;
 import org.scoula.product.domain.FundVo;
 import org.scoula.product.domain.GoldVo;
 import org.scoula.product.domain.MortgageVo;
 import org.scoula.product.domain.ProductVo;
 import org.scoula.product.domain.SavingVo;
 import org.scoula.product.domain.TrustVo;
-import org.scoula.product.dto.DepositDto;
-import org.scoula.product.dto.DepositOptionDto;
 import org.scoula.product.dto.DepositSavingOptionDto;
-import org.scoula.product.dto.FundDto;
-import org.scoula.product.dto.FundOptionDto;
 import org.scoula.product.dto.FundSimpleOptionDto;
-import org.scoula.product.dto.GoldDto;
-import org.scoula.product.dto.MortgageDto;
 import org.scoula.product.dto.MortgageOptionDto;
 import org.scoula.product.dto.ProductDto;
-import org.scoula.product.dto.SavingDto;
-import org.scoula.product.dto.SavingOptionDto;
-import org.scoula.product.dto.TrustDto;
+import org.scoula.product.mapper.FundDailyReturnMapper;
 import org.scoula.product.mapper.ProductMapper;
 import org.scoula.product.struct.ProductVoToMapper;
 import org.springframework.stereotype.Service;
@@ -35,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProductsServiceImpl implements ProductService {
 	private final ProductMapper productMapper;
+	private final FundDailyReturnMapper fundDailyReturnMapper;
 
 	/**
 	 * 전체 상품 목록으로 조회
@@ -97,4 +91,8 @@ public class ProductsServiceImpl implements ProductService {
 		return "";
 	}
 
+	@Override
+	public List<FundDailyReturnVo> getFundDailyReturnByCode(String finPrdtCd){
+		return fundDailyReturnMapper.findByFundCode(finPrdtCd);
+	}
 }

--- a/src/main/resources/org/scoula/product/mapper/FundDailyReturnMapper.xml
+++ b/src/main/resources/org/scoula/product/mapper/FundDailyReturnMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.scoula.product.mapper.FundDailyReturnMapper">
+
+    <!-- ResultMap -->
+    <resultMap id="FundDailyReturnMap" type="org.scoula.product.domain.FundDailyReturnVo" autoMapping="true">
+        <id property="id" column="id"/>
+        <result property="fundCode" column="fund_code"/>
+        <result property="recordDate" column="record_date"/>
+        <result property="returnRate" column="return_rate"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+    </resultMap>
+
+
+
+    <!-- 전체(최근일자 우선) -->
+    <select id="findByFundCode" resultMap="FundDailyReturnMap">
+        SELECT id, fund_code, record_date, return_rate, created_at, updated_at
+        FROM fund_daily_return
+        WHERE fund_code = #{fundCode}
+        ORDER BY record_date DESC, id DESC
+    </select>
+
+
+
+
+</mapper>


### PR DESCRIPTION

- [NHDR-220] Fund 3개월 수익률 기능 추가
# 📝 작업 내용
  - `FundDailyReturnVo`/`FundDailyReturnDto` 생성 (recordDate → String 변환)
  - `FundDailyReturnMapper` 및 MyBatis XML 작성
  - `ProductService`에 `getFundDailyReturnByCode()` 메서드 추가
  - `RetirementController`의 `getProductDetail` 응답 구조 변경
    - 펀드 상품(코드 1,2,3 시작)일 경우 3개월 일일 수익률 리스트 `fundReturn` 필드에 추가
  - 와일드카드(`<?>`) ResponseEntity로 변경하여 다양한 응답 타입 지원


# ✅ 체크리스트

- [x] `./gradlew build` 또는 `mvn clean install`: 정상 작동
- [x] Postman 또는 Swagger로 API 테스트 완료
- [x] 로컬 DB 연동 후 동작 확인
- [x] 예외 및 유효성 검증 로직 포함
- [x] 로그 및 주석 작성
- [x] 리뷰어 지정 및 리뷰 요청 완료
- [x] Jira in Review로 이동 완료


[NHDR-220]: https://nohudorak.atlassian.net/browse/NHDR-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ