### PR TITLE
[NHDR-224] fix: 로직 내 rule_category가 매칭되도록 수정-seyoung

### DIFF
--- a/src/main/java/org/scoula/gift/service/SimulationServiceImpl.java
+++ b/src/main/java/org/scoula/gift/service/SimulationServiceImpl.java
@@ -129,7 +129,7 @@ public class SimulationServiceImpl implements SimulationService {
 			.collect(Collectors.groupingBy(StrategyVo::getRuleCategory));
 
 		checkTotalAssetRules(recommendations, rulesByCategory.get("총 자산 규모"), taxResult);
-		checkRecipientRules(recommendations, rulesByCategory.get("수증자 관계"), taxResult);
+		checkRecipientRules(recommendations, rulesByCategory.get("수증자 유형"), taxResult);
 		checkGiftHistoryRules(recommendations, rulesByCategory.get("기존 증여이력"), taxResult);
 		checkTaxPayerRules(recommendations, rulesByCategory.get("증여세 납부자"), taxResult);
 		checkAssetTypeRules(recommendations, rulesByCategory.get("자산 유형"), requestDto);


### PR DESCRIPTION
<!-- PR명: [티켓번호] 작업 주제 - 닉네임 -->

# 📝 작업 내용

<!-- 어떤 작업을 했는지 간단한 리스트업 -->
- 로직 내 rule_category가 매칭되도록 수정 (수증자 관계 -> 수증자 유형)
<img width="992" height="198" alt="image" src="https://github.com/user-attachments/assets/fbf29e56-5ee0-4dfb-897a-27a38dfb4db0" />
- SQL문 증여 데이터 수정 후 기본 세팅에 반영
<img width="1167" height="486" alt="image" src="https://github.com/user-attachments/assets/55a0f9ae-9d03-4630-9399-705b5304274d" />

<img width="1919" height="494" alt="image" src="https://github.com/user-attachments/assets/d5e3010b-da4a-44fc-bcb9-40d198861ad9" />


# ✅ 체크리스트

- [x] `./gradlew build` 또는 `mvn clean install`: 정상 작동
- [x] Postman 또는 Swagger로 API 테스트 완료
- [x] 로컬 DB 연동 후 동작 확인
- [x] 예외 및 유효성 검증 로직 포함
- [x] 로그 및 주석 작성
- [x] 리뷰어 지정 및 리뷰 요청 완료
- [x] Jira in Review로 이동 완료
